### PR TITLE
ExecuteQuery Fixed issue 11 by changing the result to dynamic

### DIFF
--- a/Frends.MySQL.ExecuteQuery/CHANGELOG.md
+++ b/Frends.MySQL.ExecuteQuery/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [1.0.1] - 2022-01-02
+## [1.0.1] - 2023-01-02
 ### Fixed
-- Fixed issue with Task's result couldn't be referenced with dot notation by changing the resultJtoken to dynamic.
-- Changed the newtonsoft.Json version to 12.0.1 to be same what Frends is using.
+- Fixed issue with Task's result couldn't be referenced with dot notation by changing the ResultJtoken to dynamic.
+- Changed the Newtonsoft.Json version to 12.0.1 to be same what Frends is using.
 
 ## [1.0.0] - 2022-10-12
 ### Added

--- a/Frends.MySQL.ExecuteQuery/CHANGELOG.md
+++ b/Frends.MySQL.ExecuteQuery/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.1] - 2022-01-02
+### Fixed
+- Fixed issue with Task's result couldn't be referenced with dot notation by changing the resultJtoken to dynamic.
+- Changed the newtonsoft.Json version to 12.0.1 to be same what Frends is using.
+
 ## [1.0.0] - 2022-10-12
 ### Added
 - Initial implementation

--- a/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/Definitions/Result.cs
+++ b/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/Definitions/Result.cs
@@ -16,13 +16,14 @@ public class Result
     /// <summary>
     /// Result message.
     /// </summary>
+    /// <example>Success</example>
     public string Message { get; private set; }
 
     /// <summary>
     /// Result value(s).
     /// </summary>
     /// <example>[{"name": "foo", "value": 123}]</example>
-    public JToken ResultJtoken { get; private set; }
+    public dynamic ResultJtoken { get; private set; }
 
     internal Result(bool success, string message, JToken resultJtoken)
     {

--- a/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery.csproj
+++ b/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.0.0</Version>
+	<Version>1.0.1</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -24,6 +24,6 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="MySql.Data" Version="8.0.30" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Fixed issue with Task's result couldn't be referenced with dot notation by changing the resultJtoken to dynamic.
- Changed the newtonsoft.Json version to 12.0.1 to be same what Frends is using.