### PR TITLE
Fspes 19 execute query timeout issue

### DIFF
--- a/Frends.MySQL.ExecuteQuery/CHANGELOG.md
+++ b/Frends.MySQL.ExecuteQuery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] - 2025-09-22
+### Fixed
+- Respect Options.TimeoutSeconds in MySql commands
+
 ## [1.2.0] - 2025-03-18
 ### Updated
 - Update packages:

--- a/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery.Tests/UnitTests.cs
+++ b/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery.Tests/UnitTests.cs
@@ -274,7 +274,7 @@ public class UnitTests
         MySqlConnectionStringBuilder conn_string = new()
         {
             Server = "127.0.0.1",
-            Port = 3307,
+            Port = 3306,
             UserID = "root",
             Password = "my-secret-pw",
         };

--- a/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery.Tests/UnitTests.cs
+++ b/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery.Tests/UnitTests.cs
@@ -245,12 +245,36 @@ public class UnitTests
         ClassicAssert.IsTrue(check.ResultJtoken.ToString().Contains(rndName));
     }
 
+    [Test]
+    public async Task TimeoutShortQuery_ShouldThrow()
+    {
+        var options = new Options
+        {
+            TimeoutSeconds = 1,
+            MySqlTransactionIsolationLevel = MySqlTransactionIsolationLevel.RepeatableRead
+        };
+
+        var q = new QueryInput
+        {
+            ConnectionString = await CreateConnectionString(),
+            CommandText = @"
+            SELECT SLEEP(1), 'row1'
+            UNION ALL
+            SELECT SLEEP(1), 'row2';"
+        };
+
+        var ex = Assert.ThrowsAsync<Exception>(async () =>
+            await MySQL.ExecuteQuery(q, options, CancellationToken.None));
+
+        ClassicAssert.That(ex!.Message, Does.Contain("timeout").IgnoreCase);
+    }
+
     private static async Task<string> CreateConnectionString()
     {
         MySqlConnectionStringBuilder conn_string = new()
         {
             Server = "127.0.0.1",
-            Port = 3306,
+            Port = 3307,
             UserID = "root",
             Password = "my-secret-pw",
         };

--- a/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/Definitions/Options.cs
+++ b/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/Definitions/Options.cs
@@ -11,7 +11,7 @@ public class Options
     /// </summary>
     /// <example>30</example>
     [DefaultValue(30)]
-    public int TimeoutSeconds { get; set; }
+    public int TimeoutSeconds { get; set; } = 30;
 
     /// <summary>
     /// Transaction isolation level to use.

--- a/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/ExecuteQuery.cs
+++ b/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/ExecuteQuery.cs
@@ -43,7 +43,7 @@ public class MySQL
                     command.Parameters.Add(new MySqlParameter(parameter.Name, parameter.Value));
                 }
             }
-            command.CommandTimeout = command.CommandTimeout;
+            command.CommandTimeout = options.TimeoutSeconds;
 
             if (query.CommandText.ToString().ToLower().Contains("select"))
             {

--- a/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery.csproj
+++ b/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery/Frends.MySQL.ExecuteQuery.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.2.0</Version>
+	<Version>1.3.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
[]# Frends Task Pull Request

## Summary
<!-- Brief description of changes -->

## Review Checklist

### 1. Frends Task Project Files
- Path: `Frends.*/Frends.*/*.csproj`
- [ ] Targets .NET 8
- [ ] Uses MIT license (`<PackageLicenseExpression>MIT</PackageLicenseExpression>`)
- [ ] Contains required fields:
  - [ ] `<Version>`
  - [ ] `<Authors>Frends</Authors>`
  - [ ] `<Description>`
  - [ ] `<RepositoryUrl>`
  - [ ] `<GenerateDocumentationFile>true</GenerateDocumentationFile>`

### 2. File: FrendsTaskMetadata.json
- [ ] Present: `Frends.*/Frends.*/FrendsTaskMetadata.json`
- [ ] FrendsTaskMetadata.json contains correct task method reference
- [ ] FrendsTaskMetadata.json is included in the project nuget package with path = "/"

### 3. File: README.md
- [ ] Present: `Frends.*/README.md`
- [ ] Contains badges (build, license, coverage)
- [ ] Includes developer setup instructions
- [ ] Does not include parameter descriptions

### 4. File: CHANGELOG.md
- [ ] Present: `Frends.*/CHANGELOG.md`
- [ ] Includes all functional changes
- [ ] Indicates breaking changes with upgrade notes
- [ ] Avoids non-functional notes like "refactored xyz"
- [ ] CHANGELOG.md is included in the project nuget package with path = "/"

### 5. File: migration.json
- [ ] Present: `Frends.*/Frends.*/migration.json`
- [ ] Contains breaking change migration information for Frends, if breaking changes exist
- [ ] migration.json is included in the project nuget package with path = "/"

### 6. Source Code Documentation
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Every public method and class has:
  - [ ] `<summary>` XML comments
  - [ ] `<example>` XML comments
  - [ ] Optionally `<frendsdocs>` XML comments, if needed
- [ ] Follows Microsoft C# code conventions
- [ ] Uses semantic task result documentation (Success, Error, Data)

### 7. GitHub Actions Workflows
- Path: `.github/workflows/*.yml`
- [ ] Task has required workflow files:
  - [ ] `*_test.yml`
  - [ ] `*_main.yml`
  - [ ] `*_release.yml`
- [ ] Correct workdir pointing to task folder
- [ ] Docker setup included if task depends on external system (docker-compose.yml)

### 8. Task Result Object Structure
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Category attribute is present, if applicable
- [ ] All task result classes include:
  - [ ] `Success` (bool)
  - [ ] Task-specific return value (e.g., Data, FilePaths), if needed
  - [ ] Error object with Message and AdditionalInfo
- [ ] Result structure is flat and simple
- [ ] Does not use 3rd-party types
- [ ] Uses dynamic JToken only when structure is unknown


---

## Additional Notes
<!-- Any additional information for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - ExecuteQuery now respects the configured timeout, ensuring long-running MySQL commands are canceled per the set limit.
- Documentation
  - Changelog updated for version 1.3.0 noting the timeout fix.
- Tests
  - Added a unit test validating timeout behavior on long-running queries.
- Chores
  - Package version bumped to 1.3.0 and default timeout initialized to 30 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->